### PR TITLE
fix(flatbuffers): making strategy parameter properties required

### DIFF
--- a/flatbuffers/MarketDataSnapshot.fbs
+++ b/flatbuffers/MarketDataSnapshot.fbs
@@ -21,9 +21,9 @@ namespace Switchboard;
 struct MDEntry {
     // Bitset describing conditions of the quote.
     conditions: uint16;
-    /// Size of the MDEntry
+    /// Size of the MDEntry.
     size: double;
-    /// Price of the MDEntry
+    /// Price of the MDEntry.
     price: double;
 }
 

--- a/flatbuffers/NewOrderSingle.fbs
+++ b/flatbuffers/NewOrderSingle.fbs
@@ -20,11 +20,11 @@ namespace Switchboard;
 
 table StrategyParameter {
     /// Name of parameter
-    name: string;
+    name: string (required);
     /// Datatype of the parameter.
     type: StrategyParameterType;
     /// Value of the parameter.
-    value: string;
+    value: string (required);
 }
 
 /// The New Order Single message is sent by the taker to create a new order for execution.

--- a/flatbuffers/OrderCancelReject.fbs
+++ b/flatbuffers/OrderCancelReject.fbs
@@ -24,7 +24,7 @@ namespace Switchboard;
 table OrderCancelReject {
     /// Trading account.
     account: string (required);
-    /// Instrument symbol
+    /// Instrument symbol.
     symbol: string (required);
     /// Exchange or venue symbol.
     venue: string (required);

--- a/flatbuffers/OrderCancelRequest.fbs
+++ b/flatbuffers/OrderCancelRequest.fbs
@@ -25,7 +25,7 @@ namespace Switchboard;
 table OrderCancelRequest {
     /// Trading account.
     account: string (required);
-    /// Instrument symbol
+    /// Instrument symbol.
     symbol: string (required);
     /// Exchange or venue symbol.
     venue: string (required);

--- a/flatbuffers/OrderReplaceRequest.fbs
+++ b/flatbuffers/OrderReplaceRequest.fbs
@@ -23,7 +23,7 @@ namespace Switchboard;
 table OrderReplaceRequest {
     /// Trading account.
     account: string (required);
-    /// Instrument symbol
+    /// Instrument symbol.
     symbol: string (required);
     /// Exchange or venue symbol.
     venue: string (required);


### PR DESCRIPTION
If you create a strategy parameter you must supply both a name and value.