### PR TITLE
fix(flatbuffers): venue_filter should be a list

### DIFF
--- a/flatbuffers/ExecutionReport.fbs
+++ b/flatbuffers/ExecutionReport.fbs
@@ -86,6 +86,6 @@ table ExecutionReport {
     error_code: int;
     /// Supplementary information, primarily used for rejects.
     text: string;
-    /// Comma-delimited list of order execution venues specified on the order.
-    venue_filter: string;
+    /// A list of order execution venues specified on the order.
+    venue_filter: [string];
 }

--- a/flatbuffers/NewOrderSingle.fbs
+++ b/flatbuffers/NewOrderSingle.fbs
@@ -62,6 +62,6 @@ table NewOrderSingle {
     parameters: [StrategyParameter];
     /// Free text field for customer use. Max 128 characters.
     text: string;
-    /// Comma-delimited list of order execution venues. Ignored if venue is not AGG.
-    venue_filter: string;
+    /// A list of order execution venues. Ignored if venue is not AGG.
+    venue_filter: [string];
 }


### PR DESCRIPTION
Rather than encoding as a delimited string, we can encode as a vector.