### PR TITLE
fix(flatbuffers): order type in NOS is now a string

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: neomantra/flatbuffers:v1.12.0
+    container: neomantra/flatbuffers:latest
     steps:
       - name: Checkout project
         uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ generate-rust:
 .PHONY: generate-ts
 generate-ts:
 	@echo "Generating typescript files..."
-	@flatc --ts --short-names --no-fb-import -o ${DEST}/typescript ${SRC}
+	@flatc --ts --ts-flat-files -o ${DEST}/typescript ${SRC}
 
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -24,16 +24,16 @@ See our [Developer Docs](https://developer.reactivemarkets.com) for full documen
 
 The Flatbuffers schema files are located in the [flatbuffers](flatbuffers/) directory.
 
-Code can be generated for all languages supported by Flatbuffers using the `flatc` compiler:
+Code can be generated for all languages supported by Flatbuffers using the `flatc` (>= v22.11.23) compiler:
 
 ```bash
-$ flatc --rust flatbuffers/*.fbs
+flatc --rust flatbuffers/*.fbs
 ```
 
 If you don't want to install flatc, you can use a docker container as a build tool.
 
 ```bash
-docker run --rm -v $(pwd):/api neomantra/flatbuffers:v1.12.0 bash -c "flatc --rust -o /api/build/rust /api/flatbuffers/*.fbs"
+docker run --rm -v $(pwd):/api neomantra/flatbuffers:v22.11.23 bash -c "flatc --rust -o /api/build/rust /api/flatbuffers/*.fbs"
 ```
 
 ## Contributing

--- a/flatbuffers/Enum.fbs
+++ b/flatbuffers/Enum.fbs
@@ -53,13 +53,6 @@ enum OrderStatus: int16 {
     PendingNew
 }
 
-enum OrderType: int16 {
-    None = 0,
-    Market,
-    Limit,
-    PreviouslyQuoted
-}
-
 enum QuoteAckStatus: int16 {
     None = 0,
     Accepted,

--- a/flatbuffers/ExecutionReport.fbs
+++ b/flatbuffers/ExecutionReport.fbs
@@ -49,7 +49,7 @@ table ExecutionReport {
     /// Order side.
     side: Side;
     /// See OrderType.
-    order_type: OrderType;
+    order_type: string;
     /// See TimeInForce.
     time_in_force: TimeInForce;
     /// See ExecType.

--- a/flatbuffers/NewOrderSingle.fbs
+++ b/flatbuffers/NewOrderSingle.fbs
@@ -22,7 +22,7 @@ table StrategyParameter {
     /// Name of parameter
     name: string (required);
     /// Datatype of the parameter.
-    type: StrategyParameterType;
+    parameter_type: StrategyParameterType;
     /// Value of the parameter.
     value: string (required);
 }
@@ -45,7 +45,7 @@ table NewOrderSingle {
     /// Order side.
     side: Side;
     /// See OrderType
-    order_type: OrderType;
+    order_type: string;
     /// See TimeInForce
     time_in_force: TimeInForce;
     /// Order quantity. MUST be greater than zero.


### PR DESCRIPTION
We need to support dynamic order types.
StrategyParameter type has been renamed to parameter_type. Moving to flatc v22.11.23 to generate better code.

SD-2744