### PR TITLE
fix: reverting order type change and adding strategy field

### DIFF
--- a/flatbuffers/Enum.fbs
+++ b/flatbuffers/Enum.fbs
@@ -53,6 +53,13 @@ enum OrderStatus: int16 {
     PendingNew
 }
 
+enum OrderType: int16 {
+    None = 0,
+    Market,
+    Limit,
+    PreviouslyQuoted
+}
+
 enum QuoteAckStatus: int16 {
     None = 0,
     Accepted,

--- a/flatbuffers/ExecutionReport.fbs
+++ b/flatbuffers/ExecutionReport.fbs
@@ -15,6 +15,7 @@
 // See https://developer.reactivemarkets.com for documentation.
 
 include "Enum.fbs";
+include "StrategyParameter.fbs";
 
 namespace Switchboard;
 
@@ -49,7 +50,7 @@ table ExecutionReport {
     /// Order side.
     side: Side;
     /// See OrderType.
-    order_type: string;
+    order_type: OrderType;
     /// See TimeInForce.
     time_in_force: TimeInForce;
     /// See ExecType.
@@ -84,6 +85,10 @@ table ExecutionReport {
     counterparty: string;
     /// Optional code to identify the order reject reason when ExecType Rejected.
     error_code: int;
+    /// Target strategy for order execution.
+    strategy: string;
+    /// Strategy Parameters
+    strategy_parameters: [StrategyParameter];
     /// Supplementary information, primarily used for rejects.
     text: string;
     /// A list of order execution venues specified on the order.

--- a/flatbuffers/NewOrderSingle.fbs
+++ b/flatbuffers/NewOrderSingle.fbs
@@ -15,17 +15,9 @@
 // See https://developer.reactivemarkets.com for documentation.
 
 include "Enum.fbs";
+include "StrategyParameter.fbs";
 
 namespace Switchboard;
-
-table StrategyParameter {
-    /// Name of parameter
-    name: string (required);
-    /// Datatype of the parameter.
-    parameter_type: StrategyParameterType;
-    /// Value of the parameter.
-    value: string (required);
-}
 
 /// The New Order Single message is sent by the taker to create a new order for execution.
 /// The maker is expected to respond immediately with a Execution Report message under normal conditions.
@@ -44,9 +36,9 @@ table NewOrderSingle {
     security_type: SecurityType = Spot;
     /// Order side.
     side: Side;
-    /// Order Type to execute with.
-    order_type: string;
-    /// See TimeInForce
+    /// See OrderType.
+    order_type: OrderType;
+    /// See TimeInForce.
     time_in_force: TimeInForce;
     /// Order quantity. MUST be greater than zero.
     qty: double;
@@ -58,8 +50,10 @@ table NewOrderSingle {
     price_tolerance: double;
     /// Quote Indentifier.
     quote_id: string;
+    /// Target strategy for order execution.
+    strategy: string;
     /// Strategy Parameters
-    parameters: [StrategyParameter];
+    strategy_parameters: [StrategyParameter];
     /// Free text field for customer use. Max 128 characters.
     text: string;
     /// A list of order execution venues. Ignored if venue is not AGG.

--- a/flatbuffers/OrderReplaceRequest.fbs
+++ b/flatbuffers/OrderReplaceRequest.fbs
@@ -15,6 +15,7 @@
 // See https://developer.reactivemarkets.com for documentation.
 
 include "Enum.fbs";
+include "StrategyParameter.fbs";
 
 namespace Switchboard;
 
@@ -41,4 +42,6 @@ table OrderReplaceRequest {
     qty: double;
     /// The revised order price.
     price: double;
+    /// Strategy Parameters
+    strategy_parameters: [StrategyParameter];
 }

--- a/flatbuffers/StrategyParameter.fbs
+++ b/flatbuffers/StrategyParameter.fbs
@@ -1,0 +1,28 @@
+// Copyright © 2022 Reactive Markets. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// See https://developer.reactivemarkets.com for documentation.
+
+include "Enum.fbs";
+
+namespace Switchboard;
+
+table StrategyParameter {
+    /// Name of parameter
+    name: string (required);
+    /// Datatype of the parameter.
+    parameter_type: StrategyParameterType;
+    /// Value of the parameter.
+    value: string (required);
+}


### PR DESCRIPTION
We'll keep the order type enum and use a new field for strategy.