### PR TITLE
feat(flatbuffers): remove quote arrays on Quote

### DIFF
--- a/flatbuffers/Quote.fbs
+++ b/flatbuffers/Quote.fbs
@@ -64,14 +64,14 @@ table Quote {
     fixing_date: int;
     /// The settlement date in YYYYMMDD format.
     settlement_date: int;
-    /// Swaps only, fixing date in YYYYMMDD format.
+    /// Swaps only, far leg fixing date in YYYYMMDD format.
     far_fixing_date: int;
-    /// The settlement date in YYYYMMDD format.
+    /// Swaps only, far leg settlement date in YYYYMMDD format.
     far_settlement_date: int;
     /// Swaps only, far leg tenor.
     far_tenor: string;
-    /// Bid quote entries.
-    bid: [QuoteEntry];
-    /// Offer quote entries.
-    offer: [QuoteEntry];
+    /// Bid quote.
+    bid: QuoteEntry;
+    /// Offer quote.
+    offer: QuoteEntry;
 }


### PR DESCRIPTION
Quote only needs a single quoteEntry for bid and offer, we never have multiple quotes, and having arrays means we will not be able to update this definition once live

SD-3368