### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 ---
 name: ci
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/reactivemarkets/switchboard-api/security/code-scanning/1](https://github.com/reactivemarkets/switchboard-api/security/code-scanning/1)

In general, you fix this by adding an explicit `permissions` block either at the workflow root (applies to all jobs without their own `permissions`) or inside each job. For this CI workflow, the steps only read the repository contents and do not need to write anything back to GitHub, so we can safely restrict `GITHUB_TOKEN` to read‑only on `contents`.

The best minimal fix without changing existing functionality is to add a workflow‑level `permissions` block just below the `name: ci` line. This will apply to the `build` job and any future jobs that don’t override permissions. We’ll set `contents: read`, which is equivalent to GitHub’s “read‑only” default for repository contents and is sufficient for `actions/checkout@v2` to function. No imports or additional methods are needed; this is a pure YAML configuration change within `.github/workflows/ci.yml`.

Concretely:
- Edit `.github/workflows/ci.yml`.
- Insert:

```yaml
permissions:
  contents: read
```

between line 2 (`name: ci`) and line 3 (`on:`). No other changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
